### PR TITLE
revert the change to the Firebase project to install in App Messaginging

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://github.com/CocoaPods/Specs.git"/>
             </config>
             <pods>
-                <pod name="Firebase/InAppMessagingDisplay" spec="0.15.2" />
+                <pod name="Firebase/InAppMessagingDisplay" spec="~> 6.3.0" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
according to https://github.com/CocoaPods/Specs/blob/master/Specs/0/3/5/Firebase/6.3.0/Firebase.podspec.json, the pod `InAppMessagingDisplay` is hosted as a `namespaced` item within the `Firebase` package. 

Therefore we need to use `Firebase 6.3.0` to ensure we can install the correct version of `InAppMessagingDisplay` pod

- i have tested this locally using the ` "cordova-plugin-firebase-inappmessaging": "git+https://github.com/cephalo-ai/cordova-plugin-firebase-inappmessaging.git#fix-version-for-firebase-package",` as the package install command